### PR TITLE
Исправила баг обработки сообщения веб-сокета.

### DIFF
--- a/MattermostBot/IApiClient.cs
+++ b/MattermostBot/IApiClient.cs
@@ -115,8 +115,10 @@ namespace ApiClient
     /// Стартовать получение сообщений с сервера.
     /// </summary>
     /// <param name="newPostEventHandler">Обработчик событий поступления новых сообщений.</param>
+    /// <param name="errorEventHandler">Обработчик ошибок.</param>
     /// <param name="cancellationToken">Токен отмены.</param>
-    public void StartReceivingServerMessages(Action<MessageEventInfo> newPostEventHandler, CancellationToken cancellationToken);
+    public void StartReceivingServerMessages(Action<MessageEventInfo> newPostEventHandler, Action<string> errorEventHandler, 
+      CancellationToken cancellationToken);
   }
 
   /// <summary>
@@ -127,9 +129,16 @@ namespace ApiClient
     /// <summary>
     /// Зарегистрировать обработчик события появления на канале нового сообщения.
     /// </summary>
-    /// <param name="eventHandler">Обработчик события.</param>
+    /// <param name="newPostEventHandler">Обработчик события.</param>
     /// <returns>Экземпляр <see cref="IApiClientBuilder"/>.</returns>
-    public IApiClientBuilder RegisterNewPostEventHandler(Action<MessageEventInfo> eventHandler);
+    public IApiClientBuilder RegisterNewPostEventHandler(Action<MessageEventInfo> newPostEventHandler);
+
+    /// <summary>
+    /// Зарегистрировать обработчик ошибок.
+    /// </summary>
+    /// <param name="errorEventHandler">Обработчик ошибок.</param>
+    /// <returns>Экземпляр <see cref="IApiClientBuilder"/>.</returns>
+    public IApiClientBuilder RegisterErrorEventHandler(Action<string> errorEventHandler);
 
     /// <summary>
     /// Подключиться к серверу.

--- a/MattermostBot/MattermostApiAdapter.cs
+++ b/MattermostBot/MattermostApiAdapter.cs
@@ -142,7 +142,6 @@ namespace ApiAdapter
                   newPostEventHandler(
                     new MessageEventInfo() { id = postData.id, message = postData.message, channelID = postData.channel_id, userID = postData.user_id, rootID = postData.root_id });
                 }
-                Console.WriteLine(messageText);
               }
               catch (Exception ex)
               {

--- a/MattermostBot/Program.cs
+++ b/MattermostBot/Program.cs
@@ -168,6 +168,7 @@ namespace MattermostBot
         ReadConfig();
         mattermostApi = new MattermostApiClientBuilder(MattermostUri, accessToken)
           .RegisterNewPostEventHandler(m => NewPostEventHandler(m))
+          .RegisterErrorEventHandler(e => Console.WriteLine(e))
           .Connect(cancellationTokenSource.Token);
         while (true)
         {


### PR DESCRIPTION
* Исправила баг обработки сообщения веб-сокета. Теперь если сообщение больше выделенного буфера, то оно будет считываться частями, пока не наступит конец сообщения. И только после этого будет парситься.
+ Добавила обработчик ошибок. Сейчас ошибка просто выводится на консоль. При запуске бота из планировщика в этом смысла особого нет, но потом можно будет выводить ошибки в лог. 