### PR TITLE
Скорректировала условие отправки приветственного сообщения в тред.

### DIFF
--- a/MattermostBot/Program.cs
+++ b/MattermostBot/Program.cs
@@ -215,7 +215,7 @@ namespace MattermostBot
           if (channelInfo.AutoPinNewMessage)
           {
             mattermostApi.PinMessage(messageEventInfo.id);
-            if (channelInfo.WelcomeThreadMessage != null)
+            if (!string.IsNullOrEmpty(channelInfo.WelcomeThreadMessage))
             {
               SendMessageToThread(channelInfo.WelcomeThreadMessage, messageEventInfo.id, channelInfo);
             }


### PR DESCRIPTION
Описание исправленного бага: 
Роберто присылал пустое сообщение, если в конфиге было задано WelcomeThreadMessage = "".